### PR TITLE
Add debug display in top left corner

### DIFF
--- a/dist/Simulation.d.ts
+++ b/dist/Simulation.d.ts
@@ -13,6 +13,7 @@ declare class Simulation {
     private lastRenderTime;
     private startTime;
     private interval;
+    debug: Record<string, string>;
     constructor(simulationOptions: SimulationOptions);
     private createCanvas;
     private initMarkers;

--- a/dist/Simulation.js
+++ b/dist/Simulation.js
@@ -33,6 +33,7 @@ class Simulation {
         this.markers = [];
         this.lastRenderTime = 0;
         this.startTime = 0;
+        this.debug = {};
         this.animate = (time) => {
             requestAnimationFrame(this.animate);
             let deltaTime = this.lastRenderTime ? (time - this.lastRenderTime) / 1000 : 0;
@@ -45,7 +46,7 @@ class Simulation {
                 angle: this.rover.angle,
                 width: ROVER_WIDTH,
                 height: ROVER_HEIGHT
-            }, this.trace, this.markers, this.renderingOptions);
+            }, this.trace, this.markers, this.renderingOptions, this.debug);
         };
         const { loop, element, renderingOptions = {}, locationsOfInterest = [], origin } = simulationOptions;
         const { height = 500, width = 500 } = renderingOptions;
@@ -130,7 +131,8 @@ class Simulation {
             }, {
                 engines: this.engines
             });
-            const { engines } = actuatorValues;
+            const { engines, debug, } = actuatorValues;
+            this.debug = debug || {};
             if (engines.length === this.engines.length) {
                 for (let i = 0; i < engines.length; i++) {
                     if (engines[i] <= 1.0 && engines[i] >= -1.0) {

--- a/dist/render.d.ts
+++ b/dist/render.d.ts
@@ -10,4 +10,4 @@ export interface Rover {
     angle: number;
     position: Point;
 }
-export default function render(context: CanvasRenderingContext2D, rover: Rover, trace: Array<Point>, markers: Array<Marker>, options: RenderingOptions): void;
+export default function render(context: CanvasRenderingContext2D, rover: Rover, trace: Array<Point>, markers: Array<Marker>, options: RenderingOptions, debug: Record<string, string>): void;

--- a/dist/render.js
+++ b/dist/render.js
@@ -11,6 +11,15 @@ function drawRover(context, { width, height }, color) {
     context.stroke();
     context.restore();
 }
+function drawDebugValues(context, debugValues) {
+    context.save();
+    context.font = '12px monospace';
+    context.fillStyle = 'white';
+    Object.entries(debugValues).forEach(([key, value], index) => {
+        context.fillText(`${key}: ${value}`, 10, 15 + (index * 14));
+    });
+    context.restore();
+}
 function drawPath(context, { position, angle }, trace, color) {
     if (trace.length < 1)
         return;
@@ -70,7 +79,7 @@ function drawGrid(context, { position, angle }, rasterSize, color) {
     context.stroke();
     context.restore();
 }
-function render(context, rover, trace, markers, options) {
+function render(context, rover, trace, markers, options, debug) {
     const { height = 500, width = 500, showGrid = true, showTrace = true, colorTrace = 'blue', colorRover = 'red', colorMarker = 'purple', colorGrid = 'lightgreen' } = options;
     context.fillStyle = "black";
     context.fillRect(0, 0, width, height);
@@ -95,5 +104,6 @@ function render(context, rover, trace, markers, options) {
     drawMarkers(context, rover, markers, colorMarker);
     drawRover(context, rover, colorRover);
     context.restore();
+    drawDebugValues(context, debug);
 }
 exports.default = render;

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -19,6 +19,7 @@ export interface SensorValues {
 }
 export interface ActuatorValues {
     engines: Array<number>;
+    debug?: Record<string, string>;
 }
 export declare type ControlLoop = (sensors: SensorValues, actuators: ActuatorValues) => ActuatorValues;
 export interface RenderingOptions {

--- a/src/Simulation.ts
+++ b/src/Simulation.ts
@@ -95,6 +95,8 @@ class Simulation {
     private startTime: number = 0
     private interval: any
 
+    debug: Record<string, string> = {}
+
     /**
      * Initializes a new simulation an starts the visualization without starting the control loop.
      *
@@ -236,8 +238,11 @@ class Simulation {
             })
 
             const {
-                engines
+                engines,
+                debug,
             } = actuatorValues;
+
+            this.debug = debug || {};
 
             if (engines.length === this.engines.length) {
                 for(let i = 0; i < engines.length; i++){
@@ -296,7 +301,9 @@ class Simulation {
             },
             this.trace,
             this.markers,
-            this.renderingOptions);
+            this.renderingOptions,
+            this.debug,
+        );
     }
 }
 

--- a/src/render.ts
+++ b/src/render.ts
@@ -27,6 +27,19 @@ function drawRover(context: CanvasRenderingContext2D, {width, height}: Rover, co
     context.restore();
 }
 
+function drawDebugValues(context: CanvasRenderingContext2D, debugValues: Record<string, string>){
+    context.save();
+
+    // Draw debug values to top left corner
+    context.font = '12px monospace';
+    context.fillStyle = 'white';
+    Object.entries(debugValues).forEach(([key, value], index) => {
+        context.fillText(`${key}: ${value}`, 10, 15 + (index * 14))
+    })
+
+    context.restore();
+}
+
 function drawPath(context: CanvasRenderingContext2D, {position, angle}: Rover, trace: Array<Point>, color: string) {
     if(trace.length < 1) return;
 
@@ -116,7 +129,9 @@ export default function render(
     rover: Rover,
     trace: Array<Point>,
     markers: Array<Marker>,
-    options: RenderingOptions) {
+    options: RenderingOptions,
+    debug: Record<string, string>,
+) {
 
     const {
         height = 500,
@@ -168,4 +183,6 @@ export default function render(
 
     // Restore transform
     context.restore();
+
+    drawDebugValues(context, debug);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,11 @@ export interface ActuatorValues {
      * be in the range [-1.0 : 1.0], where 0 means the vehicle is at rest.
      */
     engines: Array<number>
+
+    /**
+     * Values that will be displayed in top left corner.
+     */
+    debug?: Record<string, string>
 }
 
 /**


### PR DESCRIPTION
This PR will add a debug display, using a monospaced white font, in the top left corner of the canvas.

### Usage:

`return { engines, debug: { someValue: theValue + 'theUnit' } }`

![image](https://user-images.githubusercontent.com/44374653/104052076-72315e80-51e9-11eb-9bcc-79dcb176082e.png)


Renaming the "actuatorValues" variable would probably also make sense